### PR TITLE
fix where parser=future caused "This Array Expression is not productive"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,6 @@ class keepalived (
   class { 'keepalived::install': } ->
   class { 'keepalived::config': } ->
   class { 'keepalived::service': } ->
-  Class [ 'keepalived' ]
+  Class[ 'keepalived' ]
 }
 


### PR DESCRIPTION
Enabling [parser=future](https://docs.puppetlabs.com/puppet/3/reference/experiments_future.html#enabling-the-future-parser) caused:

`Error: Could not retrieve catalog from remote server: Error 400 on SERVER: This Array Expression is not productive. A Host Class Definition can not end with a non productive construct at /etc/puppet/modules/keepalived/manifests/init.pp:35:9 on node admin022
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run`