### PR TITLE
Validate keepalived::vrrp::instance priority and virtual_router_id params

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -169,6 +169,9 @@ define keepalived::vrrp::instance (
   if (!is_integer($priority) or $priority < 1 or $priority > 254) {
     fail('priority must be an integer 1 >= and <= 254')
   }
+  if (!is_integer($virtual_router_id) or $virtual_router_id < 1 or $virtual_router_id > 255) {
+    fail('virtual_router_id must be an integer >= 1 and <= 255')
+  }
 
   concat::fragment { "keepalived.conf_vrrp_instance_${name}":
     ensure  => $ensure,

--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -166,6 +166,10 @@ define keepalived::vrrp::instance (
   $dont_track_primary         = false,
 
 ) {
+  if (!is_integer($priority) or $priority < 1 or $priority > 254) {
+    fail('priority must be an integer 1 >= and <= 254')
+  }
+
   concat::fragment { "keepalived.conf_vrrp_instance_${name}":
     ensure  => $ensure,
     target  => "${::keepalived::config_dir}/keepalived.conf",

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -7,7 +7,7 @@ describe 'keepalived::vrrp::instance', :type => :define do
   let (:mandatory_params) {
     {
       :interface         => '',
-      :priority          => '',
+      :priority          => 10,
       :state             => '',
       :virtual_ipaddress => [],
       :virtual_router_id => ''
@@ -37,19 +37,38 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter priority' do
-    let (:params) {
-      mandatory_params.merge({
-        :priority => '_VALUE_',
-      })
-    }
+    [1, 100, 254].each do |valid_priority|
+      context "with valid #{valid_priority}" do
+        let (:params) {
+          mandatory_params.merge({
+            :priority => valid_priority,
+          })
+        }
 
-    it { should create_keepalived__vrrp__instance('_NAME_') }
-    it {
-      should \
-        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
-          'content' => /priority.*_VALUE_/
-      )
-    }
+        it { should create_keepalived__vrrp__instance('_NAME_') }
+        it {
+          should \
+            contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+              'content' => /\spriority\s+#{valid_priority}$/
+          )
+        }
+      end
+    end
+
+    ['__VALUE__', -1, 0, 255, 500].each do |invalid_priority|
+      context "with invalid #{invalid_priority}" do
+        let (:params) {
+          mandatory_params.merge({
+            :priority => invalid_priority,
+          })
+        }
+
+        it {
+          expect { should create_keepalived__vrrp__instance('_NAME_') }.to \
+            raise_error(Puppet::Error, /priority must be an integer 1 >= and <= 254/)
+        }
+      end
+    end
   end
 
   describe 'with parameter state' do

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -3,6 +3,15 @@ require 'spec_helper'
 describe 'keepalived::vrrp::instance', :type => :define do
   let (:facts) { debian_facts }
   let (:pre_condition) { '$concat_basedir = "/tmp"' }
+  let (:mandatory_params) {
+    {
+      :interface         => '',
+      :priority          => '',
+      :state             => '',
+      :virtual_ipaddress => [],
+      :virtual_router_id => ''
+    }
+  }
 
   describe 'without parameters' do
     let (:title) { '_VALUE_' }
@@ -15,13 +24,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter interface' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :interface => '_VALUE_',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -36,13 +41,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter priority' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :priority => '_VALUE_',
-        :interface => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -57,13 +58,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter state' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :state => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -78,13 +75,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter virtual_ipaddress' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress => [ '_VALUE_' ],
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -99,14 +92,10 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter track_interface' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
-        :interface => '',
-        :priority => '',
-        :state => '',
+      mandatory_params.merge({
         :track_interface => [ '_VALUE_' ],
         :virtual_ipaddress => [ '_VALUE_' ],
-        :virtual_router_id => '',
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -121,14 +110,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter notify_script' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :notify_script => '_VALUE_',
-        :virtual_ipaddress => [],
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -143,14 +127,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter smtp_alert' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :smtp_alert => true,
-        :virtual_ipaddress => [],
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -165,14 +144,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter nopreempt' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :nopreempt => true,
-        :virtual_ipaddress => [],
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -187,14 +161,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter notify_script_master' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :notify_script_master => '_VALUE_',
-        :virtual_ipaddress => [],
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -209,14 +178,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter notify_script_backup' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :notify_script_backup => '_VALUE_',
-        :virtual_ipaddress => [],
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -231,14 +195,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter notify_script_fault' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :notify_script_fault => '_VALUE_',
-        :virtual_ipaddress => [],
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -253,14 +212,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter notify_script_stop' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :notify_script_stop => '_VALUE_',
-        :virtual_ipaddress => [],
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -275,14 +229,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter notify_script' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :notify_script => '_VALUE_',
-        :virtual_ipaddress => [],
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -297,13 +246,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter virtual_router_id' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_router_id => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => []
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -318,14 +263,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter: ensure' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :ensure => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -340,14 +280,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter auth_type' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :auth_type => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -362,15 +297,10 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter auth_pass' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :auth_type => '_AUTH_TYPE_',
         :auth_pass => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -385,14 +315,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter track_script' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :track_script => [ '_VALUE_' ],
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -408,14 +333,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter lvs_interface' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :lvs_interface => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -430,14 +350,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter advert_int' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :advert_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -453,14 +368,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
  describe 'with parameter garp_master_delay' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :garp_master_delay => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -476,14 +386,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
  describe 'with parameter garp_master_refresh' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :garp_master_refresh => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -499,14 +404,10 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter virtual_ipaddress_int' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
         :virtual_ipaddress => ['192.168.1.1'],
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -521,14 +422,10 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_ipaddress as hash' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
         :virtual_ipaddress => { 'ip' => '192.168.1.1'},
-        :virtual_router_id => '',
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -543,15 +440,11 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_ipaddress as array of hashes' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
         :virtual_ipaddress => [ { 'ip' => '192.168.1.1'},
                                 { 'ip' => '192.168.1.2'} ],
-        :virtual_router_id => '',
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -571,15 +464,11 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_ipaddress as hash containing device' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
         :virtual_ipaddress => [ { 'ip' => '192.168.1.1',
                                   'dev' => '_DEV_' } ],
-        :virtual_router_id => '',
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -594,15 +483,11 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_ipaddress as hash containing label' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
         :virtual_ipaddress => [ { 'ip' => '192.168.1.1',
                                   'label' => '_LABEL_' } ],
-        :virtual_router_id => '',
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -617,15 +502,11 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_ipaddress as hash containing brd' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
         :virtual_ipaddress => [ { 'ip' => '192.168.1.1',
                                   'brd' => '_BRD_' } ],
-        :virtual_router_id => '',
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -640,15 +521,11 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_ipaddress as hash containing scope' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
         :virtual_ipaddress => [ { 'ip' => '192.168.1.1',
                                   'scope' => '_SCOPE_' } ],
-        :virtual_router_id => '',
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -663,15 +540,10 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter virtual_ipaddress_excluded' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
         :virtual_ipaddress_excluded => ['192.168.1.1']
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -686,15 +558,10 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_ipaddress_excluded as hash' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
         :virtual_ipaddress_excluded => {'ip' => '192.168.1.1'},
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -709,16 +576,11 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_ipaddress_excluded as array of hashes' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
         :virtual_ipaddress_excluded => [ {'ip' => '192.168.1.1'},
                                          {'ip' => '192.168.1.2'} ],
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -738,16 +600,11 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_ipaddress_excluded as hash containing device' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
         :virtual_ipaddress_excluded => [ {'ip' => '192.168.1.1',
                                           'dev' => '_DEV_'} ],
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -762,16 +619,11 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_ipaddress_excluded as hash containing label' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
         :virtual_ipaddress_excluded => [ {'ip' => '192.168.1.1',
                                           'label' => '_LABEL_' } ],
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -786,16 +638,11 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_ipaddress_excluded as hash containing brd' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
         :virtual_ipaddress_excluded => [ {'ip' => '192.168.1.1',
                                          'brd' => '_BRD_'} ],
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -810,16 +657,11 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_ipaddress_excluded as hash containing scope' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
         :virtual_ipaddress_excluded => [ {'ip' => '192.168.1.1',
                                           'scope' => '_SCOPE_'} ],
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -834,15 +676,10 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter virtual_routes not in a hash' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
         :virtual_routes => ['192.168.1.0/24']
-      }
+      })
     }
 
     it do
@@ -854,15 +691,10 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_routes as hash' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
         :virtual_routes => {'to' => '10.0.1.0/24', 'via' => '192.168.0.1'},
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -877,15 +709,10 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_routes as array of hashes' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
+      mandatory_params.merge({
         :virtual_routes => [ {'to' => '10.0.1.0/24', 'via' => '192.168.0.1'},
                              {'to' => '10.0.2.0/24', 'via' => '192.168.0.2'} ],
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -905,16 +732,11 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_routes as hash containing device parameter' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
+      mandatory_params.merge({
         :virtual_routes => [ {'to'  => '10.0.1.0/24',
                               'via' => '192.168.0.1',
                               'dev' => '_DEV_'} ],
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -929,16 +751,11 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_routes as hash containing src parameter' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
+      mandatory_params.merge({
         :virtual_routes => [ {'to'  => '10.0.1.0/24',
                               'via' => '192.168.0.1',
                               'src' => '_SOURCE_'} ],
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -953,17 +770,12 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with virtual_routes as hash containing scope parameter' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
         :virtual_routes => [ {'to'    => '10.0.1.0/24',
                               'via'   => '192.168.0.1',
                               'scope' => '_SCOPE_'} ],
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -978,14 +790,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter unicast_source_ip' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
+      mandatory_params.merge({
         :unicast_source_ip => '_VALUE_',
-        :virtual_ipaddress => [],
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_router_id => ''
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -1000,14 +807,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with unicast_peers as array containing unicast peer ip addresses' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
+      mandatory_params.merge({
         :unicast_peers => [ '10.0.1.0', '10.0.2.0' ],
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
@@ -1026,14 +828,9 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with dont_track_primary' do
     let (:title) { '_NAME_' }
     let (:params) {
-      {
-        :interface => '',
-        :priority => '',
-        :state => '',
-        :virtual_ipaddress => [],
-        :virtual_router_id => '',
+      mandatory_params.merge({
         :dont_track_primary => true,
-      }
+      })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'keepalived::vrrp::instance', :type => :define do
+  let (:title) { '_NAME_' }
   let (:facts) { debian_facts }
   let (:pre_condition) { '$concat_basedir = "/tmp"' }
   let (:mandatory_params) {
@@ -14,15 +15,12 @@ describe 'keepalived::vrrp::instance', :type => :define do
   }
 
   describe 'without parameters' do
-    let (:title) { '_VALUE_' }
-
     it do
       expect { should create_class('keepalived') }.to raise_error(Puppet::Error)
     end
   end
 
   describe 'with parameter interface' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :interface => '_VALUE_',
@@ -39,7 +37,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter priority' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :priority => '_VALUE_',
@@ -56,7 +53,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter state' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :state => '_VALUE_',
@@ -73,7 +69,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter virtual_ipaddress' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress => [ '_VALUE_' ],
@@ -90,7 +85,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter track_interface' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :track_interface => [ '_VALUE_' ],
@@ -108,7 +102,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter notify_script' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :notify_script => '_VALUE_',
@@ -125,7 +118,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter smtp_alert' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :smtp_alert => true,
@@ -142,7 +134,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter nopreempt' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :nopreempt => true,
@@ -159,7 +150,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter notify_script_master' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :notify_script_master => '_VALUE_',
@@ -176,7 +166,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter notify_script_backup' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :notify_script_backup => '_VALUE_',
@@ -193,7 +182,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter notify_script_fault' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :notify_script_fault => '_VALUE_',
@@ -210,7 +198,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter notify_script_stop' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :notify_script_stop => '_VALUE_',
@@ -227,7 +214,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter notify_script' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :notify_script => '_VALUE_',
@@ -244,7 +230,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter virtual_router_id' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_router_id => '_VALUE_',
@@ -261,7 +246,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter: ensure' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :ensure => '_VALUE_',
@@ -278,7 +262,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter auth_type' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :auth_type => '_VALUE_',
@@ -295,7 +278,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter auth_pass' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :auth_type => '_AUTH_TYPE_',
@@ -313,7 +295,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter track_script' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :track_script => [ '_VALUE_' ],
@@ -331,7 +312,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter lvs_interface' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :lvs_interface => '_VALUE_',
@@ -348,7 +328,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter advert_int' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :advert_int => '_VALUE_',
@@ -366,7 +345,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
  describe 'with parameter garp_master_delay' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :garp_master_delay => '_VALUE_',
@@ -384,7 +362,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
  describe 'with parameter garp_master_refresh' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :garp_master_refresh => '_VALUE_',
@@ -402,7 +379,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter virtual_ipaddress_int' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -420,7 +396,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
     end
 
   describe 'with virtual_ipaddress as hash' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -438,7 +413,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with virtual_ipaddress as array of hashes' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -462,7 +436,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
 
   # device in hash overrides anything
   describe 'with virtual_ipaddress as hash containing device' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -481,7 +454,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with virtual_ipaddress as hash containing label' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -500,7 +472,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with virtual_ipaddress as hash containing brd' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -519,7 +490,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with virtual_ipaddress as hash containing scope' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -538,7 +508,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter virtual_ipaddress_excluded' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -556,7 +525,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
     end
 
   describe 'with virtual_ipaddress_excluded as hash' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -574,7 +542,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with virtual_ipaddress_excluded as array of hashes' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -598,7 +565,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
 
   # device in hash overrides anything
   describe 'with virtual_ipaddress_excluded as hash containing device' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -617,7 +583,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with virtual_ipaddress_excluded as hash containing label' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -636,7 +601,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with virtual_ipaddress_excluded as hash containing brd' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -655,7 +619,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with virtual_ipaddress_excluded as hash containing scope' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -674,7 +637,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter virtual_routes not in a hash' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -689,7 +651,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with virtual_routes as hash' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -707,7 +668,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with virtual_routes as array of hashes' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_routes => [ {'to' => '10.0.1.0/24', 'via' => '192.168.0.1'},
@@ -730,7 +690,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
 
   # device in hash overrides anything
   describe 'with virtual_routes as hash containing device parameter' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_routes => [ {'to'  => '10.0.1.0/24',
@@ -749,7 +708,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with virtual_routes as hash containing src parameter' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_routes => [ {'to'  => '10.0.1.0/24',
@@ -768,7 +726,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with virtual_routes as hash containing scope parameter' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :virtual_ipaddress_int => '_VALUE_',
@@ -788,7 +745,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with parameter unicast_source_ip' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :unicast_source_ip => '_VALUE_',
@@ -805,7 +761,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
 
   describe 'with unicast_peers as array containing unicast peer ip addresses' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :unicast_peers => [ '10.0.1.0', '10.0.2.0' ],
@@ -826,7 +781,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
   end
   
   describe 'with dont_track_primary' do
-    let (:title) { '_NAME_' }
     let (:params) {
       mandatory_params.merge({
         :dont_track_primary => true,


### PR DESCRIPTION
#### Validate VRRP instance priority

Validate that the `priorty` param provided to `keepalived::vrrp::instance`
is semantically valid. This will catch errors early, before keepalived is
incorrectly configured.

The RFC states that the priority is an 8bit unsigned integer which means
that it must have a range of 0-255 inclusive. However it also goes on to say
that 0 and 255 are reserved for special operational use.

https://tools.ietf.org/html/rfc3768#section-5.3.4

#### Validate VRRP virtual_router_id

Validate that the `virtual_router_id` param provided to
`keepalived::vrrp::instance` is semantically valid. This will catch errors
early, before keepalived is incorrectly configured.

The RFC states that the router ID must have a range of 1-255 inclusive.

https://tools.ietf.org/html/rfc3768#section-5.3.3

---

Plus reducing repetition in the tests for `keepalived::vrrp::instance` to make them easier to read.