### PR TITLE
Test for the 'which' method before using it

### DIFF
--- a/lib/facter/keepalived_version.rb
+++ b/lib/facter/keepalived_version.rb
@@ -11,7 +11,7 @@
 #
 # Notes:
 #   None
-if Facter::Util::Resolution.which('keepalived')
+if defined?(Facter::Util::Resolution.which) and Facter::Util::Resolution.which('keepalived')
   Facter.add(:keepalived_version) do
     setcode do
       Facter::Util::Resolution.exec('keepalived --version 2>&1').lines.first.match(/Keepalived v(\d+\.\d+\.\d+) .+/)[1]


### PR DESCRIPTION
Older versions of facter don't have the "which" method