### PR TITLE
Split integer and value check into separate if statements

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -116,10 +116,10 @@
 # $unicast_source_ip::     default IP for binding vrrpd is the primary IP
 #                          on interface. If you want to hide the location of vrrpd,
 #                          use this IP as src_addr for unicast vrrp packets.
-#                          Default: undef. 
+#                          Default: undef.
 #
 # $unicast_peers::         Do not send VRRP adverts over VRRP multicast group.
-#                          Instead send adverts to the list of ip addresses using 
+#                          Instead send adverts to the list of ip addresses using
 #                          a unicast design fashion.
 #
 #                          May be specified as an array with ip addresses
@@ -168,10 +168,16 @@ define keepalived::vrrp::instance (
 ) {
   $_name = regsubst($name, '[:\/\n]', '')
 
-  if (!is_integer($priority) or $priority < 1 or $priority > 254) {
+  if (!is_integer($priority)){
+    fail('priority must be an integer')
+  }
+  if ($priority < 1 or $priority > 254) {
     fail('priority must be an integer 1 >= and <= 254')
   }
-  if (!is_integer($virtual_router_id) or $virtual_router_id < 1 or $virtual_router_id > 255) {
+  if (!is_integer($virtual_router_id) {
+    fail('virtual_router_id must be an integer')
+  }
+  if ($virtual_router_id < 1 or $virtual_router_id > 255) {
     fail('virtual_router_id must be an integer >= 1 and <= 255')
   }
 
@@ -182,4 +188,3 @@ define keepalived::vrrp::instance (
     order   => '100',
   }
 }
-

--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -174,7 +174,7 @@ define keepalived::vrrp::instance (
   if ($priority < 1 or $priority > 254) {
     fail('priority must be an integer 1 >= and <= 254')
   }
-  if (!is_integer($virtual_router_id) {
+  if (!is_integer($virtual_router_id)) {
     fail('virtual_router_id must be an integer')
   }
   if ($virtual_router_id < 1 or $virtual_router_id > 255) {

--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -169,13 +169,13 @@ define keepalived::vrrp::instance (
   $_name = regsubst($name, '[:\/\n]', '')
 
   if (!is_integer($priority)){
-    fail('priority must be an integer')
+    fail('priority must be an integer 1 >= and <= 254')
   }
   if ($priority < 1 or $priority > 254) {
     fail('priority must be an integer 1 >= and <= 254')
   }
   if (!is_integer($virtual_router_id)) {
-    fail('virtual_router_id must be an integer')
+    fail('virtual_router_id must be an integer >= 1 and <= 255')
   }
   if ($virtual_router_id < 1 or $virtual_router_id > 255) {
     fail('virtual_router_id must be an integer >= 1 and <= 255')


### PR DESCRIPTION
Remove the possibility that a comparison will be done between a string and an integer by failing earlier

Fixes: 

```
2015-10-07 09:42:19,045 ERROR [puppet-server] Puppet Evaluation Error: Comparison of: String < Integer, is not possible. Caused by 'A String is not comparable to a non String'.
```

Closes https://github.com/arioch/puppet-keepalived/issues/79