### PR TITLE
Type cast strings to integers for puppet 4

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -168,10 +168,10 @@ define keepalived::vrrp::instance (
 ) {
   $_name = regsubst($name, '[:\/\n]', '')
 
-  if (!is_integer($priority) or $priority < 1 or $priority > 254) {
+  if (!is_integer($priority) or ($priority + 0) < 1 or ($priority + 0) > 254) {
     fail('priority must be an integer 1 >= and <= 254')
   }
-  if (!is_integer($virtual_router_id) or $virtual_router_id < 1 or $virtual_router_id > 255) {
+  if (!is_integer($virtual_router_id) or ($virtual_router_id + 0) < 1 or ($virtual_router_id + 0) > 255) {
     fail('virtual_router_id must be an integer >= 1 and <= 255')
   }
 


### PR DESCRIPTION
Puppet 4 will not automatically cast strings to integers for the sake of comparison, so we can add 0 to each string to force a type casting before doing the comparison.