### PR TITLE
add define keepalived::lvs::real_server::misc_check

### DIFF
--- a/manifests/lvs/real_server.pp
+++ b/manifests/lvs/real_server.pp
@@ -47,6 +47,13 @@ define keepalived::lvs::real_server (
   concat::fragment { "keepalived.conf_lvs_real_server_${_name}":
     target  => "${::keepalived::config_dir}/keepalived.conf",
     content => template('keepalived/lvs_real_server.erb'),
+    order   => "250-${virtual_server}-${_name}-000",
+  }
+
+  concat::fragment { "keepalived.conf_lvs_real_server_${_name}-footer":
+    target  => "${::keepalived::config_dir}/keepalived.conf",
+    content => "  }\n",
     order   => "250-${virtual_server}-${_name}",
   }
+
 }

--- a/manifests/lvs/real_server/misc_check.pp
+++ b/manifests/lvs/real_server/misc_check.pp
@@ -1,0 +1,40 @@
+# == Define: keepalived::lvs::real_server::misc_check
+#
+# Add a misc check to a specific real_server
+#
+# === Parameters
+#
+# Refer to keepalived's documentation to understand the behaviour
+# of these parameters
+#
+# [*virtual_server*]
+#   The name of the virtual server the real server belongs to
+#
+# [*real_server*]
+#   The name of the real server this check will be added to
+#
+# [*misc_path*]
+#   The path to the executable of the misc check
+#
+# [*misc_timeout*]
+#   The timeout of the misc check
+#
+# [*misc_dynamic*]
+#   Wheter or not the returnc code of the misc check is interpreded as weight
+
+define keepalived::lvs::real_server::misc_check (
+  $virtual_server,
+  $real_server,
+  $misc_path,
+  $misc_timeout = 0,
+  $misc_dynamic = false,
+) {
+  $_real_server = regsubst($real_server, '[:\/\n]', '')
+  $_name = regsubst($name, '[:\/\n]', '')
+
+  concat::fragment { "keepalived.conf_lvs_real_server_misc_check_${_name}":
+    target  => "${::keepalived::config_dir}/keepalived.conf",
+    content => template('keepalived/lvs_real_server_misc_check.erb'),
+    order   => "250-${virtual_server}-${_real_server}-${_name}",
+  }
+}

--- a/manifests/lvs/real_server/misc_check.pp
+++ b/manifests/lvs/real_server/misc_check.pp
@@ -26,11 +26,15 @@ define keepalived::lvs::real_server::misc_check (
   $virtual_server,
   $real_server,
   $misc_path,
-  $misc_timeout = 0,
+  $misc_timeout = undef,
   $misc_dynamic = false,
 ) {
   $_real_server = regsubst($real_server, '[:\/\n]', '')
   $_name = regsubst($name, '[:\/\n]', '')
+
+  if $misc_timeout {
+    validate_re($misc_timeout, '^\d+$')
+  }
 
   concat::fragment { "keepalived.conf_lvs_real_server_misc_check_${_name}":
     target  => "${::keepalived::config_dir}/keepalived.conf",

--- a/spec/defines/keepalived_lvs_real_server_misc_check_spec.rb
+++ b/spec/defines/keepalived_lvs_real_server_misc_check_spec.rb
@@ -1,0 +1,29 @@
+
+require 'spec_helper'
+
+describe 'keepalived::lvs::real_server::misc_check', :type => 'define' do
+  let(:title) { 'test' }
+  let(:facts) { debian_facts }
+  let(:pre_condition) { '$concat_basedir = "/tmp"' }
+
+  context 'with bare minimum: real_server, misc_path' do
+    let(:params) {
+      {
+        :virtual_server => 'virt1',
+        :real_server => 'real1',
+        :misc_path => '/bin/true'
+      }
+    }
+
+    it {
+      should contain_concat__fragment('keepalived.conf_lvs_real_server_misc_check_test').with( {
+        'content' => <<-CONTENT.gsub(/ {10}/, '  ')
+            MISC_CHECK {
+              misc_path "/bin/true"
+            }
+        CONTENT
+      })
+    }
+  end
+
+end

--- a/spec/defines/keepalived_lvs_real_server_misc_check_spec.rb
+++ b/spec/defines/keepalived_lvs_real_server_misc_check_spec.rb
@@ -1,6 +1,13 @@
 
 require 'spec_helper'
 
+# explicitely enable both syntaxes to avoid deprecation warnung
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+end
+
 describe 'keepalived::lvs::real_server::misc_check', :type => 'define' do
   let(:title) { 'test' }
   let(:facts) { debian_facts }

--- a/spec/defines/keepalived_lvs_real_server_spec.rb
+++ b/spec/defines/keepalived_lvs_real_server_spec.rb
@@ -19,6 +19,10 @@ describe 'keepalived::lvs::real_server', :type => 'define' do
       should contain_concat__fragment('keepalived.conf_lvs_real_server_test').with( {
         'content' => <<-CONTENT.gsub(/ {10}/, '  ')
           real_server 127.3.4.5 8080 {
+        CONTENT
+      })
+      should contain_concat__fragment('keepalived.conf_lvs_real_server_test-footer').with( {
+        'content' => <<-CONTENT.gsub(/ {10}/, '  ')
           }
         CONTENT
       })
@@ -90,6 +94,10 @@ describe 'keepalived::lvs::real_server', :type => 'define' do
                 connect_ip 127.0.0.1
               }
             }
+        CONTENT
+      })
+      should contain_concat__fragment('keepalived.conf_lvs_real_server_test-footer').with( {
+        'content' => <<-CONTENT.gsub(/ {10}/, '  ')
           }
         CONTENT
       })
@@ -119,6 +127,10 @@ describe 'keepalived::lvs::real_server', :type => 'define' do
                 connect_ip 127.0.0.1
               }
             }
+        CONTENT
+      })
+      should contain_concat__fragment('keepalived.conf_lvs_real_server_test-footer').with( {
+        'content' => <<-CONTENT.gsub(/ {10}/, '  ')
           }
         CONTENT
       })
@@ -144,6 +156,10 @@ describe 'keepalived::lvs::real_server', :type => 'define' do
             inhibit_on_failure
             notify_up 'notify-send "good to go!"'
             weight 1
+        CONTENT
+      })
+      should contain_concat__fragment('keepalived.conf_lvs_real_server_test-footer').with( {
+        'content' => <<-CONTENT.gsub(/ {10}/, '  ')
           }
         CONTENT
       })

--- a/templates/lvs_real_server.erb
+++ b/templates/lvs_real_server.erb
@@ -24,4 +24,3 @@
   end
 -%>
   real_server <%= @ip_address %> <%= @port %> {<%= format_options(@options) %>
-  }

--- a/templates/lvs_real_server_misc_check.erb
+++ b/templates/lvs_real_server_misc_check.erb
@@ -1,0 +1,9 @@
+    MISC_CHECK {
+      misc_path "<%= @misc_path %>"
+<% if @misc_timeout != 0 -%>
+      misc_timeout <%= @misc_timeout %>
+<% end -%>
+<% if @misc_dynamic -%>
+      misc_dynamic
+<% end -%>
+    }

--- a/templates/lvs_real_server_misc_check.erb
+++ b/templates/lvs_real_server_misc_check.erb
@@ -1,6 +1,6 @@
     MISC_CHECK {
       misc_path "<%= @misc_path %>"
-<% if @misc_timeout != 0 -%>
+<% if @misc_timeout -%>
       misc_timeout <%= @misc_timeout %>
 <% end -%>
 <% if @misc_dynamic -%>


### PR DESCRIPTION
The current way to specify checks for keepalived::lvs::real_server within an options parameter
has at least two problems:
 * you can't specify more than one check of a certain type (e.g. two ore more checks of type MISC_CHECK, which is what we really need in our setup)
 * there is no validation for the CHECK syntax / options

This PR fixes that for MISC_CHECK, by introducing a new define for this kind of check.