### PR TITLE
future parser: removed Class[ 'keepalived' ]

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,6 @@ class keepalived (
 
   class { 'keepalived::install': } ->
   class { 'keepalived::config': } ->
-  class { 'keepalived::service': } ->
-  Class[ 'keepalived' ]
+  class { 'keepalived::service': }
 }
 


### PR DESCRIPTION
rror 400 on SERVER: This Array Expression has no effect. A Host Class
Definition can not end with a value-producing expression without other
effect at keepalived/manifests/init.pp:35:9