### PR TITLE
Keepalived should be restarted on Concat changes, not File

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,7 +9,7 @@ class keepalived::config {
   }
 
   if $::keepalived::service_manage == true {
-    File {
+    Concat {
       notify  => Service[$::keepalived::service_name],
     }
   }


### PR DESCRIPTION
Keepalived currently only restarts if /etc/keepalived folder is created, which is on clean install. It does not restart if keepalived.conf is changed.

This PR proposes to do so by subscribing keepalived service resource to keepalived.conf concat instead of /etc/keepalived folder.