### PR TITLE
Added mcast_src_ip option

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -113,10 +113,15 @@
 # $notify_script::         Define the notify script.
 #                          Default: undef.
 #
+# $multicast_source_ip::   default IP for binding vrrpd is the primary IP
+#                          on interface. If you want to hide the location of vrrpd,
+#                          use this IP as src_addr for multicast vrrp packets.
+#                          Default: undef.
+#
 # $unicast_source_ip::     default IP for binding vrrpd is the primary IP
 #                          on interface. If you want to hide the location of vrrpd,
 #                          use this IP as src_addr for unicast vrrp packets.
-#                          Default: undef. 
+#                          Default: undef.
 #
 # $unicast_peers::         Do not send VRRP adverts over VRRP multicast group.
 #                          Instead send adverts to the list of ip addresses using 
@@ -160,6 +165,7 @@ define keepalived::vrrp::instance (
   $notify_script_fault        = undef,
   $notify_script_stop         = undef,
   $notify_script              = undef,
+  $multicast_source_ip        = undef,
   $unicast_source_ip          = undef,
   $unicast_peers              = undef,
   $dont_track_primary         = false,

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -784,6 +784,22 @@ describe 'keepalived::vrrp::instance', :type => :define do
     }
   end
 
+  describe 'with parameter multicast_source_ip' do
+    let (:params) {
+      mandatory_params.merge({
+        :multicast_source_ip => '_VALUE_',
+      })
+    }
+
+    it { should create_keepalived__vrrp__instance('_NAME_') }
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /mcast_src_ip.*_VALUE_/
+      )
+    }
+  end
+
   describe 'with unicast_peers as array containing unicast peer ip addresses' do
     let (:params) {
       mandatory_params.merge({

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -138,6 +138,9 @@ vrrp_instance <%= @_name %> {
   }
   <%- end -%>
 
+  <%- if @multicast_source_ip -%>
+  mcast_src_ip <%= @multicast_source_ip %>
+  <%- end -%>
   <%- if @unicast_source_ip -%>
   unicast_src_ip <%= @unicast_source_ip %>
   <%- end -%>


### PR DESCRIPTION
Hi,

we have machines with multiple interfaces. We have to set this options, since the machine has no primary ip on the second interface where the service ip binded.