### PR TITLE
simple ordering fix for #75

### DIFF
--- a/manifests/lvs/virtual_server.pp
+++ b/manifests/lvs/virtual_server.pp
@@ -152,7 +152,7 @@ define keepalived::lvs::virtual_server (
   concat::fragment { "keepalived.conf_lvs_virtual_server_${_name}-footer":
     target  => "${::keepalived::config_dir}/keepalived.conf",
     content => "}\n",
-    order   => "250-${_name}",
+    order   => "250-${_name}-zzz",
   }
 
   if $collect_exported {


### PR DESCRIPTION
This PR is just the simplest fix for #75 mentioned by rotulet. It simply appends 'zzz' to the ordering for the closing bracket fragment to ensure the bracket is placed at the end of the block rather than the front.

Looks like the overall ordering works out as follows:

> 001 = config (header)
> 002 = vrrp/script
> 010 = global_defs
> 050 = vrrp/sync_group
> 100 = vrrp/instance
> 250 = lvs/real_server with 250-${virtual_server}-${_name}
> 250 = lvs/virtual_server with 250-${_name}-000
> 250 = lvs/virtual_server with 250-${_name} **<-- this is the problematic bracket**
> 999 = config (footer)

Appending 'zzz' seems a bit kludgy, but I believe it works while retaining the overall ordering that currently exists (with the bracket corrected). If you have a better approach I would be happy to do a PR for it.