### PR TITLE
Remove $enable in concat::fragment

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -181,7 +181,6 @@ define keepalived::vrrp::instance (
   }
 
   concat::fragment { "keepalived.conf_vrrp_instance_${_name}":
-    ensure  => $ensure,
     target  => "${::keepalived::config_dir}/keepalived.conf",
     content => template('keepalived/vrrp_instance.erb'),
     order   => '100',

--- a/manifests/vrrp/sync_group.pp
+++ b/manifests/vrrp/sync_group.pp
@@ -35,7 +35,6 @@ define keepalived::vrrp::sync_group (
   $_name = regsubst($name, '[:\/\n]', '')
 
   concat::fragment { "keepalived.conf_vrrp_sync_group_${_name}":
-    ensure  => $ensure,
     target  => "${::keepalived::config_dir}/keepalived.conf",
     content => template('keepalived/vrrp_sync_group.erb'),
     order   => '050',


### PR DESCRIPTION
To make disappear this warning
```Warning: Scope(Concat::Fragment[keepalived.conf_vrrp_instance_vip1]): The $ensure parameter to concat::fragment is deprecated and has no effect.```