### PR TITLE
Add VMAC interface if needed

### DIFF
--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -47,6 +47,8 @@
 #
 # $virtual_router_id::     Set virtual router id.
 #
+# $use_vmac::              Create a macvlan interface named vrrp.{virtual_router_id}
+#
 # $ensure::                Default: present.
 #
 # $auth_type::             Set authentication method.
@@ -144,6 +146,7 @@ define keepalived::vrrp::instance (
   $priority,
   $state,
   $virtual_router_id,
+  $use_vmac                   = undef,
   $virtual_ipaddress          = undef,
   $ensure                     = present,
   $auth_type                  = undef,

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -298,6 +298,23 @@ describe 'keepalived::vrrp::instance', :type => :define do
       )
     }
   end
+  
+  describe 'with parameter use_vmac' do
+    let (:params) {
+      mandatory_params.merge({
+        :use_vmac => '_VALUE_',
+      })
+    }
+
+    it { should create_keepalived__vrrp__instance('_NAME_') }
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /use_vmac/,
+        'content' => /vmac_xmit_base/
+      )
+    }
+  end
 
   describe 'with parameter auth_type' do
     let (:params) {

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -2,6 +2,10 @@ vrrp_instance <%= @_name %> {
   interface                 <%= @interface %>
   state                     <%= @state %>
   virtual_router_id         <%= @virtual_router_id %>
+  <%- if @use_vmac -%>
+  use_vmac
+  vmac_xmit_base
+  <%- end -%>
   priority                  <%= @priority %>
   advert_int                <%= @advert_int %>
   garp_master_delay         <%= @garp_master_delay %>


### PR DESCRIPTION
In some networks (behind some routers with NAT port rule forwarding to Virtual IP) the IP floatting is not recognized by router if mac is chanched (flag CM in the ARP table).
Additional VMAC interface solves this problem and router add the correct entry to ARP table allowing preserve a virtual IP.
To reach that goal Keepalived VRRP framework implements 10 VMAC support by the invocation of 'use_vmac' keyword in configuration file.