### PR TITLE
Added concat 2.x compability

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,26 @@ node /node02/ {
 }
 ```
 
+or hiera:
+
+```yaml
+---
+keepalived::vrrp_script:
+  check_nginx:
+    script: '/usr/bin/killall -0 nginx'
+
+keepalived::vrrp_instance:
+  VI_50:
+    interface: 'eth1'
+    state: 'MASTER'
+    virtual_router_id: '50'
+    priority: '101'
+    auth_type: 'PASS'
+    auth_pass: 'secret'
+    virtual_ipaddress: '10.0.0.1/29'
+    track_script: check_nginx
+```
+
 ### Global definitions
 
 ```puppet

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,5 +40,7 @@ class keepalived::config {
   }
 
   create_resources(keepalived::vrrp::instance, $::keepalived::vrrp_instance)
+  create_resources(keepalived::vrrp::script, $::keepalived::vrrp_script)
+  create_resources(keepalived::vrrp::sync_group, $::keepalived::vrrp_sync_group)
 }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,8 @@ class keepalived (
   $service_name       = $::keepalived::params::service_name,
   $service_restart    = $::keepalived::params::service_restart,
   $vrrp_instance      = {},
+  $vrrp_script        = {},
+  $vrrp_sync_group    = {},
 ) inherits keepalived::params {
   validate_absolute_path($config_dir)
   validate_re($config_dir_mode, '^[0-9]+$')
@@ -29,6 +31,9 @@ class keepalived (
   validate_bool($service_hasstatus)
   validate_bool($service_manage)
   validate_string($service_name)
+  validate_hash($vrrp_instance)
+  validate_hash($vrrp_script)
+  validate_hash($vrrp_sync_group)
 
   class { 'keepalived::install': } ->
   class { 'keepalived::config': } ->

--- a/manifests/lvs/virtual_server.pp
+++ b/manifests/lvs/virtual_server.pp
@@ -152,7 +152,7 @@ define keepalived::lvs::virtual_server (
   concat::fragment { "keepalived.conf_lvs_virtual_server_${_name}-footer":
     target  => "${::keepalived::config_dir}/keepalived.conf",
     content => "}\n",
-    order   => "250-${_name}",
+    order   => "250-${_name}-zzz",
   }
 
   if $collect_exported {

--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -143,8 +143,8 @@ define keepalived::vrrp::instance (
   $interface,
   $priority,
   $state,
-  $virtual_ipaddress,
   $virtual_router_id,
+  $virtual_ipaddress          = undef,
   $ensure                     = present,
   $auth_type                  = undef,
   $auth_pass                  = undef,
@@ -180,11 +180,12 @@ define keepalived::vrrp::instance (
     fail('virtual_router_id must be an integer >= 1 and <= 255')
   }
 
-  concat::fragment { "keepalived.conf_vrrp_instance_${_name}":
-    ensure  => $ensure,
-    target  => "${::keepalived::config_dir}/keepalived.conf",
-    content => template('keepalived/vrrp_instance.erb'),
-    order   => '100',
+  if ($ensure == 'present') {
+    concat::fragment { "keepalived.conf_vrrp_instance_${_name}":
+      target  => "${::keepalived::config_dir}/keepalived.conf",
+      content => template('keepalived/vrrp_instance.erb'),
+      order   => '100',
+    }
   }
 }
 

--- a/manifests/vrrp/script.pp
+++ b/manifests/vrrp/script.pp
@@ -19,12 +19,16 @@
 # $rise::     required number of successes for OK switch.
 #             Default: undef
 #
+# $timeout::  max time to wait for the vrrp script to return.
+#             Default: undef
+#
 define keepalived::vrrp::script (
   $interval  = '2',
   $script    = undef,
   $weight    = undef,
   $fall      = undef,
   $rise      = undef,
+  $timeout   = undef,
   $no_weight = false,
 ) {
   $_name = regsubst($name, '[:\/\n]', '')

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "arioch-keepalived",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "author": "Tom De Vylder",
   "summary": "Keepalived module",
   "license": "Apache License, Version 2.0",

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -286,16 +286,14 @@ describe 'keepalived::vrrp::instance', :type => :define do
   describe 'with parameter: ensure' do
     let (:params) {
       mandatory_params.merge({
-        :ensure => '_VALUE_',
+        :ensure => 'absent',
       })
     }
 
     it { should create_keepalived__vrrp__instance('_NAME_') }
     it {
-      should \
-        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
-        'ensure' => /_VALUE_/
-      )
+      should_not \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_')
     }
   end
 

--- a/spec/defines/keepalived_vrrp_script_spec.rb
+++ b/spec/defines/keepalived_vrrp_script_spec.rb
@@ -119,5 +119,24 @@ describe 'keepalived::vrrp::script', :type => :define do
       )
     }
   end
+
+  describe 'with parameter timeout' do
+    let (:title) { '_TITLE_' }
+    let (:params) {
+      {
+        :timeout => '_VALUE_',
+        :script  => '_SCRIPT_'
+      }
+    }
+
+    it { should create_keepalived__vrrp__script('_TITLE_') }
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_script__TITLE_').with(
+          'content' => /timeout.*_VALUE_/
+      )
+    }
+  end
+
 end
 

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -87,6 +87,7 @@ vrrp_instance <%= @_name %> {
   }
   <%- end -%>
 
+  <%- if @virtual_ipaddress -%>
   virtual_ipaddress {
   <%- if @virtual_ipaddress.class == Hash -%>
     <%- vips = [ @virtual_ipaddress ] -%>
@@ -103,6 +104,7 @@ vrrp_instance <%= @_name %> {
     <%- end -%>
   <%- end -%>
   }
+  <%- end -%>
 
   <%- if @virtual_ipaddress_excluded -%>
   virtual_ipaddress_excluded {

--- a/templates/vrrp_script.erb
+++ b/templates/vrrp_script.erb
@@ -10,5 +10,8 @@ vrrp_script <%= @_name %> {
   <%- if @rise -%>
   rise      <%= @rise %>
   <%- end -%>
+  <%- if @timeout -%>
+  timeout      <%= @timeout %>
+  <%- end -%>
 }
 


### PR DESCRIPTION
On every puppet run, I received this error:

```
2016-09-07 15:19:25,643 WARN  [qtp608010242-75] [puppetserver] Scope(Concat::Fragment[keepalived.conf_vrrp_instance_VRRP_3]) The $ensure parameter to concat::fragment is deprecated and has no effect.
```