### PR TITLE
Avoid newline (and with this a refresh of service) for existing configs

### DIFF
--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -31,8 +31,8 @@ vrrp_instance <%= @_name %> {
   <%- if @vmac_xmit_base -%>
   vmac_xmit_base
   <%- end -%>
-  <%- end -%>
 
+  <%- end -%>
   # notify scripts and alerts are optional
   #
   # filenames of scripts to run on transitions


### PR DESCRIPTION
When upgrading from 1.2.4 to 1.2.5, the new version schedules a refresh because of a newline in templates/vrrp_instance.erb

This commit avoids having a refresh of the keepalived service with an existing configuration.