### PR TITLE
keepalived 1.2.23 error at reading configuration file

### DIFF
--- a/spec/defines/keepalived_lvs_virtual_server_spec.rb
+++ b/spec/defines/keepalived_lvs_virtual_server_spec.rb
@@ -25,7 +25,7 @@ describe 'keepalived::lvs::virtual_server', :type => 'define' do
 
     it {
       should contain_concat__fragment('keepalived.conf_lvs_virtual_server__TITLE_').with( {
-        'content' => /^group _TITLE_ \{\s+virtual_server 10.1.1.1 8080\s+lb_algo lc\s+lb_kind NAT\s+protocol TCP\s+/
+        'content' => /^virtual_server 10.1.1.1 8080 \{\s+lb_algo lc\s+lb_kind NAT\s+protocol TCP\s+/
       })
       should contain_concat__fragment('keepalived.conf_lvs_virtual_server__TITLE_-footer').with( {
         'content' => /^\}/
@@ -43,7 +43,7 @@ describe 'keepalived::lvs::virtual_server', :type => 'define' do
 
     it {
       should contain_concat__fragment('keepalived.conf_lvs_virtual_server__TITLE_').with( {
-        'content' => /^group _TITLE_ \{\s+virtual_server fwmark 123\s+lb_algo lc\s+lb_kind NAT\s+protocol TCP\s+/
+        'content' => /^virtual_server fwmark 123 \{\s+lb_algo lc\s+lb_kind NAT\s+protocol TCP\s+/
       })
       should contain_concat__fragment('keepalived.conf_lvs_virtual_server__TITLE_-footer').with( {
         'content' => /^\}/

--- a/templates/lvs_virtual_server.erb
+++ b/templates/lvs_virtual_server.erb
@@ -1,10 +1,8 @@
-group <%= @_name %> {
-
-  <%- if @fwmark -%>
-  virtual_server fwmark <%= @fwmark %>
-  <%- else -%>
-  virtual_server <%= @ip_address %> <%= @port %>
-  <%- end -%>
+<%- if @fwmark -%>
+virtual_server fwmark <%= @fwmark %> {
+<%- else -%>
+virtual_server <%= @ip_address %> <%= @port %> {
+<%- end -%>
 
   <%- if @delay_loop -%>
   delay_loop <%= @delay_loop %>


### PR DESCRIPTION
I have this errors from my configuration generated with the latest version of puppet-keepalived and with the v1.2.23 of keepalived. Here is an extract from 'syslog':
```
Oct 19 14:12:49 host Keepalived_vrrp[11933]: Unknown keyword 'group'
Oct 19 14:12:49 host Keepalived_vrrp[11933]: Missing '{' at beginning of configuration block
```

Group keyword generate error from v1.2.23. According to man page, it must be replaced by one of:
```
virtual_server IP port |
virtual_server fwmark int |
virtual_server group string
```

Regards.