### PR TITLE
Modify daemon runtime options via sysconf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,6 +14,14 @@ class keepalived::config {
     }
   }
 
+  file { "/etc/${::keepalived::sysconf_dir}/keepalived":
+    ensure  => file,
+    owner   => 0,
+    group   => 0,
+    mode    => '0644',
+    content => template("keepalived/keepalived.${::keepalived::sysconf_dir}.erb"),
+  }
+
   file { $::keepalived::config_dir:
     ensure => directory,
     group  => $::keepalived::config_group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,8 @@
 # == Class keepalived
 #
 class keepalived (
+  $sysconf_dir        = $::keepalived::params::sysconf_dir,
+  $sysconf_options    = $::keepalived::params::sysconf_options,
   $config_dir         = $::keepalived::params::config_dir,
   $config_dir_mode    = $::keepalived::params::config_dir_mode,
   $config_file_mode   = $::keepalived::params::config_file_mode,
@@ -21,6 +23,8 @@ class keepalived (
   $vrrp_script        = {},
   $vrrp_sync_group    = {},
 ) inherits keepalived::params {
+  validate_string($sysconf_dir)
+  validate_string($sysconf_options)
   validate_absolute_path($config_dir)
   validate_re($config_dir_mode, '^[0-9]+$')
   validate_re($config_file_mode, '^[0-9]+$')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,8 @@ class keepalived::params {
 
   case $::osfamily {
     'redhat': {
+      $sysconf_dir        = 'sysconfig'
+      $sysconf_options    = '-D'
       $config_dir         = '/etc/keepalived'
       $config_dir_mode    = '0755'
       $config_file_mode   = '0644'
@@ -24,6 +26,8 @@ class keepalived::params {
     }
 
     'debian': {
+      $sysconf_dir        = 'default'
+      $sysconf_options    = ''
       $config_dir         = '/etc/keepalived'
       $config_dir_mode    = '0755'
       $config_file_mode   = '0644'
@@ -38,6 +42,8 @@ class keepalived::params {
     }
 
     'gentoo': {
+      $sysconf_dir        = 'conf.d'
+      $sysconf_options    = '-D'
       $config_dir         = '/etc/keepalived'
       $config_dir_mode    = '0755'
       $config_file_mode   = '0644'

--- a/templates/keepalived.conf.d.erb
+++ b/templates/keepalived.conf.d.erb
@@ -1,0 +1,2 @@
+# Keepalived options
+KEEPALIVED_OPTS="<%= scope.lookupvar('keepalived::sysconf_options') %>"

--- a/templates/keepalived.default.erb
+++ b/templates/keepalived.default.erb
@@ -1,0 +1,4 @@
+# Options to pass to keepalived
+
+# DAEMON_ARGS are appended to the keepalived command-line
+DAEMON_ARGS="<%= scope.lookupvar('keepalived::sysconf_options') %>"

--- a/templates/keepalived.sysconfig.erb
+++ b/templates/keepalived.sysconfig.erb
@@ -1,0 +1,14 @@
+# Options for keepalived. See `keepalived --help' output and keepalived(8) and
+# keepalived.conf(5) man pages for a list of all options. Here are the most
+# common ones :
+#
+# --vrrp               -P    Only run with VRRP subsystem.
+# --check              -C    Only run with Health-checker subsystem.
+# --dont-release-vrrp  -V    Dont remove VRRP VIPs & VROUTEs on daemon stop.
+# --dont-release-ipvs  -I    Dont remove IPVS topology on daemon stop.
+# --dump-conf          -d    Dump the configuration data.
+# --log-detail         -D    Detailed log messages.
+# --log-facility       -S    0-7 Set local syslog facility (default=LOG_DAEMON)
+#
+
+KEEPALIVED_OPTIONS="<%= scope.lookupvar('keepalived::sysconf_options') %>"


### PR DESCRIPTION
This adds the ability to modify the runtime options.
I haven't tested it on debian or gentoo.