### PR TITLE
add support for HTTP_GET, SSL_GET and MISC_CHECK

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'puppet', puppetversion
 gem 'rspec',     '~> 2.0'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
 gem 'rake',      '~> 10.0'  if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
 gem 'json',      '<= 1.8'   if RUBY_VERSION < '2.0.0'
-gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+gem 'json_pure', '< 2.0.0'  if RUBY_VERSION < '2.0.0'
 
 if puppetversion =~ /^3/
   ## rspec-hiera-puppet is puppet 3 only

--- a/templates/lvs_virtual_server.erb
+++ b/templates/lvs_virtual_server.erb
@@ -49,6 +49,31 @@ group <%= @_name %> {
       connect_timeout <%= @tcp_check['connect_timeout'] %>
     }
       <%- end -%>
+      <%- if @http_get -%>
+    <% if @http_get['use_ssl'] %>SSL_GET<% else %>HTTP_GET<% end %> {
+      connect_port <%= rs_port %>
+      connect_timeout <%= @http_get['connect_timeout'] %>
+      <%- for @url in @http_get['urls'] -%>
+      url {
+        path <%= @url['path'] %>
+        digest <%= @url['digest'] %>
+        <%- if @url['status_code'] -%>
+        status_code <%= @url['status_code'] %>
+        <%- end -%>
+      }
+      <%- end -%>
+    }
+      <%- end -%>
+      <%- if @misc_check -%>
+    MISC_CHECK {
+      misc_timeout <%= @misc_check['timeout'] %>
+      misc_path <%= @misc_check['path'] %>
+      <%- if @misc_check['dynamic'] -%>
+      misc_dynamic
+      <%- end -%>
+      user <%= @misc_check['user'] %>
+    }
+      <%- end -%>
   }
     <%- end -%>
 


### PR DESCRIPTION
This PR add support for HTTP_GET, SSL_GET and MISC_CHECK.

I've implemented SSL_GET as an option to the new $http_get option, to keep code duplication to a minimum.

This would fix the old #73, since the original reporter didn't provide a PR.