### PR TITLE
Deprecate virtual_server's $tcp_check in favor of new $real_server_options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'puppet', puppetversion
 gem 'rspec',     '~> 2.0'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
 gem 'rake',      '~> 10.0'  if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
 gem 'json',      '<= 1.8'   if RUBY_VERSION < '2.0.0'
-gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+gem 'json_pure', '< 2.0.0'  if RUBY_VERSION < '2.0.0'
 
 if puppetversion =~ /^3/
   ## rspec-hiera-puppet is puppet 3 only

--- a/spec/defines/keepalived_lvs_virtual_server_spec.rb
+++ b/spec/defines/keepalived_lvs_virtual_server_spec.rb
@@ -233,25 +233,6 @@ describe 'keepalived::lvs::virtual_server', :type => 'define' do
     }
   end
 
-  context 'with a real_server with a TCP_CHECK' do
-    let(:params) {
-      {
-        :ip_address   => '10.1.1.1',
-        :port         => '8080',
-        :lb_algo      => 'lc',
-        :tcp_check    => { 'connect_timeout' => 5 },
-        :real_servers => [ { 'ip_address' => '10.1.1.2',
-                             'port'       => '8081'}]
-      }
-    }
-
-    it {
-      should contain_concat__fragment('keepalived.conf_lvs_virtual_server__TITLE_').with( {
-        'content' => /real_server 10.1.1.2 8081 \{\s+TCP_CHECK \{\s+connect_port 8081\s+connect_timeout 5\s+\}\s+\}/
-      })
-    }
-  end
-
   context 'with a real_server without a port should default to VIP port' do
     let(:params) {
       {

--- a/spec/defines/keepalived_lvs_virtual_server_spec.rb
+++ b/spec/defines/keepalived_lvs_virtual_server_spec.rb
@@ -233,6 +233,55 @@ describe 'keepalived::lvs::virtual_server', :type => 'define' do
     }
   end
 
+  context 'with a real_server with a TCP_CHECK and non-overwritting real_server_options' do
+    let(:params) {
+      {
+        :ip_address          => '10.1.1.1',
+        :port                => '8080',
+        :lb_algo             => 'lc',
+        :tcp_check           => { 'connect_timeout' => 5 },
+        :real_servers        => [ { 'ip_address' => '10.1.1.2',
+                                    'port'       => '8081'}],
+        :real_server_options => {
+          'MISC_CHECK' => {
+            'misc_path' => 'somepath'
+          }
+        },
+      }
+    }
+
+    it {
+      should contain_concat__fragment('keepalived.conf_lvs_virtual_server__TITLE_').with( {
+        'content' => /real_server 10.1.1.2 8081 \{\s+MISC_CHECK \{\s+misc_path somepath\s+\}\s+TCP_CHECK \{\s+connect_port 8081\s+connect_timeout 5\s+\}\s+\}/
+      })
+    }
+  end
+
+  context 'with a real_server with a TCP_CHECK and overwritting real_server_options' do
+    let(:params) {
+      {
+        :ip_address          => '10.1.1.1',
+        :port                => '8080',
+        :lb_algo             => 'lc',
+        :tcp_check           => { 'connect_timeout' => 5 },
+        :real_servers        => [ { 'ip_address' => '10.1.1.2',
+                                    'port'       => '8081'}],
+        :real_server_options => {
+          'TCP_CHECK' => {
+            'connect_port'    => 42,
+            'connect_timeout' => 10
+          }
+        },
+      }
+    }
+
+    it {
+      should contain_concat__fragment('keepalived.conf_lvs_virtual_server__TITLE_').with( {
+        'content' => /real_server 10.1.1.2 8081 \{\s+TCP_CHECK \{\s+connect_port 42\s+connect_timeout 10\s+\}\s+\}/
+      })
+    }
+  end
+  
   context 'with a real_server without a port should default to VIP port' do
     let(:params) {
       {

--- a/templates/_format_options.erb
+++ b/templates/_format_options.erb
@@ -1,0 +1,25 @@
+<%-
+  def format_options(options, indent_level=2)
+    buffer = ''
+    indent = '  ' * indent_level
+
+    sorted_options = options.sort_by do |key, value|
+      value.is_a?(Hash) ? 'zzz' : key
+    end
+
+    sorted_options.each_with_index do |(key, value), index|
+      if value.is_a?(Hash)
+        buffer << "\n" unless index == 0
+        buffer << "\n#{indent}#{key} {"
+        buffer << format_options(value, indent_level+1)
+        buffer << "\n#{indent}}"
+      elsif value === true
+        buffer << "\n#{indent}#{key}"
+      else
+        buffer << "\n#{indent}#{key} #{value}"
+      end
+    end
+
+    buffer
+  end
+-%>

--- a/templates/lvs_real_server.erb
+++ b/templates/lvs_real_server.erb
@@ -1,27 +1,3 @@
-<%-
-  def format_options(options, indent_level=2)
-    buffer = ''
-    indent = '  ' * indent_level
-
-    sorted_options = options.sort_by do |key, value|
-      value.is_a?(Hash) ? 'zzz' : key
-    end
-
-    sorted_options.each_with_index do |(key, value), index|
-      if value.is_a?(Hash)
-        buffer << "\n" unless index == 0
-        buffer << "\n#{indent}#{key} {"
-        buffer << format_options(value, indent_level+1)
-        buffer << "\n#{indent}}"
-      elsif value === true
-        buffer << "\n#{indent}#{key}"
-      else
-        buffer << "\n#{indent}#{key} #{value}"
-      end
-    end
-
-    buffer
-  end
--%>
+  <%- scope.function_template(['keepalived/_format_options.erb']) -%>
   real_server <%= @ip_address %> <%= @port %> {<%= format_options(@options) %>
   }

--- a/templates/lvs_virtual_server.erb
+++ b/templates/lvs_virtual_server.erb
@@ -39,16 +39,20 @@ group <%= @_name %> {
   sorry_server <%= @sorry_server['ip_address'] %> <%= @sorry_server['port'] %>
   <%- end -%>
 
+  <%- scope.function_template(['keepalived/_format_options.erb']) -%>
   <%- if @real_servers -%>
     <%- Array(@real_servers).each do |rs| -%>
       <%- rs_port = rs['port'] || @port -%>
-  real_server <%= rs['ip_address'] %> <%= rs_port %> {
-      <%- if @tcp_check -%>
-    TCP_CHECK {
-      connect_port <%= rs_port %>
-      connect_timeout <%= @tcp_check['connect_timeout'] %>
-    }
-      <%- end -%>
+      <%-
+      options = @real_server_options
+      if @tcp_check and not options.has_key?('TCP_CHECK')
+        options['TCP_CHECK'] = {
+          'connect_port' => rs_port,
+          'connect_timeout' => @tcp_check['connect_timeout']
+        }
+      end
+      -%>
+  real_server <%= rs['ip_address'] %> <%= rs_port %> {<%= format_options(options) %>
   }
     <%- end -%>
 


### PR DESCRIPTION
Currently `keepalived::lvs::virtual_server` has a `$real_servers` parameter that optionally adds checks to real servers based on the `$tcp_check`. This is considerably different (and more limited) than how exported/collected `keepalived::lvs::real_servers`s work, namely with an arbitrarily extensible `$options` parameter.

This PR brings both ways of adding `real_server`s closer together by adding a `$real_server_options`. This complements and deprecates the `$tcp_check` parameter.
The new `$real_server_options` parameter is also used as default for all `real_server`s, including those created via exported/collected resources.

An even more homogeneous solution might be to accept "full" hashes as `$real_servers` and use `create_resources` to instantiate `keepalived::lvs::real_server`s, but this would make keeping backward compatibility trickier.

This replaces #122 