### PR TITLE
Add support for custom VMAC interface names.

### DIFF
--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -836,6 +836,22 @@ describe 'keepalived::vrrp::instance', :type => :define do
     }
   end
 
+  describe 'with use_vmac => "vrrp250"' do
+    let (:params) {
+      mandatory_params.merge({
+        :use_vmac => 'vrrp250',
+      })
+    }
+
+    it { should create_keepalived__vrrp__instance('_NAME_') }
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /\suse_vmac\s+vrrp250$/
+      )
+    }
+  end
+
   describe 'with vmac_xmit_base' do
     let (:params) {
       mandatory_params.merge({

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -27,7 +27,7 @@ vrrp_instance <%= @_name %> {
   <%- end -%>
 
   <%- if @use_vmac -%>
-  use_vmac
+  use_vmac <%= @use_vmac.is_a?(String) ? @use_vmac : '' %>
   <%- if @vmac_xmit_base -%>
   vmac_xmit_base
   <%- end -%>


### PR DESCRIPTION
This PR implements support for a custom macvlan interface name as specified by [the documentation](https://fossies.org/linux/keepalived/doc/NOTE_vrrp_vmac.txt#l_62):

> The `use_vmac` keyword will drive keepalived code to create a macvlan interface
> named `vrrp.250` (default internal paradigm is `vrrp.{virtual_router_id}`, you can
> override this naming by giving an argument to `use_vmac` keyword, eg: `use_vmac
> vrrp250`).