### PR TITLE
Support table property for virtual_routes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,8 +39,8 @@ class keepalived (
   validate_hash($vrrp_script)
   validate_hash($vrrp_sync_group)
 
-  class { 'keepalived::install': } ->
-  class { 'keepalived::config': } ->
-  class { 'keepalived::service': }
+  class { 'keepalived::install': }
+  -> class { 'keepalived::config': }
+  -> class { 'keepalived::service': }
 }
 

--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -29,7 +29,8 @@
 #                             e.g. `{ 'src' => '10.0.0.1',
 #                                     'to' => '192.168.30.0/24',
 #                                     'via' => '10.0.0.254' }`
-#                             Supported properties: src, to, via, dev, scope
+#                             Supported properties: src, to, via, dev, scope,
+#                                                   table.
 #
 # $virtual_ipaddress_excluded:: For cases with large numbers (eg 200) of IPs
 #                               on the same interface. To decrease the number

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -752,6 +752,25 @@ describe 'keepalived::vrrp::instance', :type => :define do
     }
   end
 
+  describe 'with virtual_routes as hash containing table parameter' do
+    let (:params) {
+      mandatory_params.merge({
+        :virtual_ipaddress_int => '_VALUE_',
+        :virtual_routes => [ {'to'    => '10.0.1.0/24',
+                              'via'   => '192.168.0.1',
+                              'table' => '_TABLE_'} ],
+      })
+    }
+
+    it { should create_keepalived__vrrp__instance('_NAME_') }
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /table _TABLE_ to 10.0.1.0\/24 via 192.168.0.1/
+      )
+    }
+  end
+
   describe 'with parameter unicast_source_ip' do
     let (:params) {
       mandatory_params.merge({

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -141,7 +141,7 @@ vrrp_instance <%= @_name %> {
     <%- vroutes = @virtual_routes -%>
   <%- end -%>
   <%- vroutes.each do |route| -%>
-    <%- attrs = Hash[ route.select { |k,v| ['src', 'to', 'via', 'dev', 'scope'].include? k } ] -%>
+    <%- attrs = Hash[ route.select { |k,v| ['src', 'to', 'via', 'dev', 'scope', 'table'].include? k } ] -%>
     <%= route['route'] %>  <%= attrs.sort_by{ |k,v| k }.entries.join ' ' %>
   <%- end -%>
   }


### PR DESCRIPTION
This commit adds support for the `table` attribute on `virtual_routes` entries and related tests.

Also, this fixes a minor issue with `init.pp` which made puppet-lint unhappy (and thus marked all CI builds as failing).