### PR TITLE
Fix 130

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,9 @@ fixtures:
   repositories:
     concat:
       repo: 'https://github.com/puppetlabs/puppetlabs-concat.git'
-      ref:  '1.0.0'
+      ref:  '4.0.1'
     stdlib:
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref:  '4.6.0'
+      ref:  '4.19.0'
   symlinks:
     keepalived: "#{source_dir}"

--- a/manifests/global_defs.pp
+++ b/manifests/global_defs.pp
@@ -17,12 +17,20 @@
 # $router_id::                Define the router ID.
 #                             Default: undef.
 #
+# $script_user                Set the global script_user option.
+#                             Default: undef.
+#
+# $enable_script_security::   Set the enable_script_security option.
+#                             Default: undef.
+#
 class keepalived::global_defs(
   $notification_email      = undef,
   $notification_email_from = undef,
   $smtp_server             = undef,
   $smtp_connect_timeout    = undef,
   $router_id               = undef,
+  $script_user             = undef,
+  $enable_script_security  = undef,
 ) inherits keepalived::params {
   concat::fragment { 'keepalived.conf_globaldefs':
     target  => "${::keepalived::params::config_dir}/keepalived.conf",

--- a/spec/classes/keepalived_global_defs_spec.rb
+++ b/spec/classes/keepalived_global_defs_spec.rb
@@ -99,4 +99,34 @@ describe 'keepalived::global_defs', :type => :class do
     }
   end
 
+  describe 'with parameter script_user' do
+    let (:params) {
+      {
+        :script_user => '_VALUE_'
+      }
+    }
+
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_globaldefs').with(
+        'content' => /script_user _VALUE_$/
+      )
+    }
+  end
+
+  describe 'with parameter enable_script_security' do
+    let (:params) {
+      {
+        :enable_script_security => true
+      }
+    }
+
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_globaldefs').with(
+        'content' => /enable_script_security$/
+      )
+    }
+  end
+
 end

--- a/spec/classes/keepalived_spec.rb
+++ b/spec/classes/keepalived_spec.rb
@@ -15,8 +15,7 @@ describe 'keepalived', :type => :class do
       )
     }
 
-    it { should contain_file('/etc/keepalived/keepalived.conf').with(
-        'ensure' => 'present',
+    it { should contain_concat('/etc/keepalived/keepalived.conf').with(
         'group'  => 'root',
         'mode'   => '0644',
         'owner'  => 'root'
@@ -53,7 +52,7 @@ describe 'keepalived', :type => :class do
   describe 'with parameter: config_file_mode' do
     let (:params) { { :config_file_mode => '0644' } }
 
-    it { should contain_file('/etc/keepalived/keepalived.conf').with(
+    it { should contain_concat('/etc/keepalived/keepalived.conf').with(
         'mode' => '0644'
       )
     }

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -456,6 +456,32 @@ describe 'keepalived::vrrp::instance', :type => :define do
     }
   end
 
+  describe 'with virtual_ipaddress as array of hashes and array of ips' do
+    let (:params) {
+      mandatory_params.merge({
+        :virtual_ipaddress_int => '_VALUE_',
+        :virtual_ipaddress => [ { 'ip' => '192.168.1.1'},
+                                { 'ip' => [ '192.168.1.2', '192.168.1.3' ]} ],
+      })
+    }
+
+    it { should create_keepalived__vrrp__instance('_NAME_') }
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /192.168.1.1 dev _VALUE_/
+      )
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /192.168.1.2 dev _VALUE_/
+      )
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /192.168.1.3 dev _VALUE_/
+      )
+    }
+  end
+
   # device in hash overrides anything
   describe 'with virtual_ipaddress as hash containing device' do
     let (:params) {
@@ -471,6 +497,27 @@ describe 'keepalived::vrrp::instance', :type => :define do
       should \
         contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
         'content' => /192.168.1.1 dev _DEV_/
+      )
+    }
+  end
+  describe 'with virtual_ipaddress as hash containing device and array of ips' do
+    let (:params) {
+      mandatory_params.merge({
+        :virtual_ipaddress_int => '_VALUE_',
+        :virtual_ipaddress => [ { 'ip' => ['192.168.1.1','192.168.1.2'],
+                                  'dev' => '_DEV_' } ],
+      })
+    }
+
+    it { should create_keepalived__vrrp__instance('_NAME_') }
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /192.168.1.1 dev _DEV_/
+      )
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /192.168.1.2 dev _DEV_/
       )
     }
   end
@@ -563,6 +610,27 @@ describe 'keepalived::vrrp::instance', :type => :define do
     }
   end
 
+  describe 'with virtual_ipaddress_excluded as hash with array of ips' do
+    let (:params) {
+      mandatory_params.merge({
+        :virtual_ipaddress_int => '_VALUE_',
+        :virtual_ipaddress_excluded => {'ip' => [ '192.168.1.1', '192.168.1.2' ]},
+      })
+    }
+
+    it { should create_keepalived__vrrp__instance('_NAME_') }
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /^\s+192.168.1.1 dev _VALUE_/
+      )
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /^\s+192.168.1.2 dev _VALUE_/
+      )
+    }
+  end
+
   describe 'with virtual_ipaddress_excluded as array of hashes' do
     let (:params) {
       mandatory_params.merge({
@@ -600,6 +668,27 @@ describe 'keepalived::vrrp::instance', :type => :define do
       should \
         contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
         'content' => /192.168.1.1 dev _DEV_/
+      )
+    }
+  end
+  describe 'with virtual_ipaddress_excluded as hash containing device and array of ips' do
+    let (:params) {
+      mandatory_params.merge({
+        :virtual_ipaddress_int => '_VALUE_',
+        :virtual_ipaddress_excluded => [ {'ip' => ['192.168.1.1','192.168.1.2'],
+                                          'dev' => '_DEV_'} ],
+      })
+    }
+
+    it { should create_keepalived__vrrp__instance('_NAME_') }
+    it {
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /192.168.1.1 dev _DEV_/
+      )
+      should \
+        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
+        'content' => /192.168.1.2 dev _DEV_/
       )
     }
   end

--- a/templates/globaldefs.erb
+++ b/templates/globaldefs.erb
@@ -18,5 +18,11 @@ global_defs {
   <%- if @router_id -%>
   router_id <%= @router_id %>
   <%- end -%>
+  <%- if @script_user -%>
+  script_user <%= @script_user %>
+  <%- end -%>
+  <%- if @enable_script_security -%>
+  enable_script_security
+  <%- end -%>
 }
 

--- a/templates/vrrp_instance.erb
+++ b/templates/vrrp_instance.erb
@@ -105,7 +105,7 @@ vrrp_instance <%= @_name %> {
     <%- if ip.class == Hash -%>
       <%- device = ip['dev'] || @virtual_ipaddress_int || @interface -%>
       <%- attrs = Hash[ ip.select { |k,v| ['label', 'brd', 'scope'].include? k } ] -%>
-    <%= ip['ip'] %> dev <%= device %> <%= attrs.sort_by{ |k,v| k }.entries.join ' ' %>
+    <%= Array(ip['ip']).collect{|lip| "#{lip} dev #{device} #{attrs.sort_by{ |k,v| k }.entries.join ' '}" }.join("\n    ") %>
     <%- else -%>
     <%= ip %> dev <%= @virtual_ipaddress_int || @interface %>
     <%- end -%>
@@ -124,8 +124,7 @@ vrrp_instance <%= @_name %> {
     <%- if ip.class == Hash -%>
       <%- device = ip['dev'] || @virtual_ipaddress_int || @interface -%>
       <%- attrs = Hash[ ip.select { |k,v| ['label', 'brd', 'scope'].include? k } ] -%>
-      <%= ip['ip'] %> dev <%= device %> <%= attrs.sort_by{ |k,v| k }.entries.join ' ' %>
-
+    <%= Array(ip['ip']).collect{|lip| "#{lip} dev #{device} #{attrs.sort_by{ |k,v| k }.entries.join ' '}" }.join("\n    ") %>
     <%- else -%>
       <%= ip %> dev <%= @virtual_ipaddress_int || @interface %>
     <%- end -%>


### PR DESCRIPTION
This fixes #130, implements a way to easily add multiple IPs per device for `virtual_address` and `virtual_address_excludes` and updates dependent modules to a more recent version.