### PR TITLE
Fix puppet-lint arrow warning

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,8 +39,8 @@ class keepalived (
   validate_hash($vrrp_script)
   validate_hash($vrrp_sync_group)
 
-  class { 'keepalived::install': } ->
-  class { 'keepalived::config': } ->
-  class { 'keepalived::service': }
+  class { 'keepalived::install': }
+  -> class { 'keepalived::config': }
+  -> class { 'keepalived::service': }
 }
 


### PR DESCRIPTION
FIXED: arrow should be on the right operand's line on line 42
FIXED: arrow should be on the right operand's line on line 43