### PR TITLE
Support SNMP for keepalived.

### DIFF
--- a/manifests/global_defs.pp
+++ b/manifests/global_defs.pp
@@ -23,6 +23,27 @@
 # $enable_script_security::   Set the enable_script_security option.
 #                             Default: undef.
 #
+# $snmp_socket::              Define snmp master agent socker
+#                             Default: unix:/var/agentx/master
+#
+# $enable_snmp_keepalived::   Set enable_snmp_keepalived option.
+#                             Default: undef.
+#
+# $enable_snmp_checker::      Set enable_snmp_keepalived option.
+#                             Default: undef.
+#
+# $enable_snmp_rfc::          Set enable_snmp_keepalived option.
+#                             Default: undef.
+#
+# $enable_snmp_rfcv2::        Set enable_snmp_keepalived option.
+#                             Default: undef.
+#
+# $enable_snmp_rfcv3::        Set enable_snmp_keepalived option.
+#                             Default: undef.
+#
+# $enable_traps::             Set enable_snmp_keepalived option.
+#                             Default: undef.
+#
 class keepalived::global_defs(
   $notification_email      = undef,
   $notification_email_from = undef,
@@ -31,6 +52,13 @@ class keepalived::global_defs(
   $router_id               = undef,
   $script_user             = undef,
   $enable_script_security  = undef,
+  $enable_snmp_keepalived  = undef,
+  $enable_snmp_checker     = undef,
+  $enable_snmp_rfc         = undef,
+  $enable_snmp_rfcv2       = undef,
+  $enable_snmp_rfcv3       = undef,
+  $enable_traps            = undef,
+  $snmp_socket             = 'unix:/var/agentx/master',
 ) inherits keepalived::params {
   concat::fragment { 'keepalived.conf_globaldefs':
     target  => "${::keepalived::params::config_dir}/keepalived.conf",

--- a/templates/globaldefs.erb
+++ b/templates/globaldefs.erb
@@ -24,5 +24,27 @@ global_defs {
   <%- if @enable_script_security -%>
   enable_script_security
   <%- end -%>
+  <%- if @enable_snmp_keepalived -%>
+  enable_snmp_keepalived
+  <%- end -%>
+  <%- if @enable_snmp_checker -%>
+  enable_snmp_checker
+  <%- end -%>
+  <%- if @enable_snmp_rfc -%>
+  enable_snmp_rfc
+  <%- end -%>
+  <%- if @enable_snmp_rfcv2 -%>
+  enable_snmp_rfcv2
+  <%- end -%>
+  <%- if @enable_snmp_rfcv3 -%>
+  enable_snmp_rfcv3
+  <%- end -%>
+  <%- if @enable_traps -%>
+  enable_traps
+  <%- end -%>
+  <%- if @snmp_socket -%>
+  snmp_socket <%= @snmp_socket -%>
+  <%- end -%>
+
 }
 


### PR DESCRIPTION
SNMP support can be enabled with additional arguments for the global_defs class and the corresponding template